### PR TITLE
Highlighter now works on the whole line.

### DIFF
--- a/examples/Repl/JavaScriptHighlighter.cs
+++ b/examples/Repl/JavaScriptHighlighter.cs
@@ -1,4 +1,6 @@
+using Esprima;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace RadLine.Examples
 {
@@ -41,10 +43,9 @@ namespace RadLine.Examples
 
             return highlighter;
         }
-
-        public Style Highlight(string token)
+        public IRenderable BuildHighlightedText(string text)
         {
-            return _highlighter.Highlight(token);
+            return _highlighter.BuildHighlightedText(text);
         }
     }
 }

--- a/src/RadLine/IHighlighter.cs
+++ b/src/RadLine/IHighlighter.cs
@@ -1,9 +1,9 @@
-using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace RadLine
 {
     public interface IHighlighter
     {
-        Style? Highlight(string token);
+        IRenderable BuildHighlightedText(string text);
     }
 }

--- a/src/RadLine/Internal/LineEditorAnsiBuilder.cs
+++ b/src/RadLine/Internal/LineEditorAnsiBuilder.cs
@@ -239,14 +239,7 @@ namespace RadLine
                 return new Text(text);
             }
 
-            var paragraph = new Paragraph();
-            foreach (var token in StringTokenizer.Tokenize(text))
-            {
-                var style = string.IsNullOrWhiteSpace(token) ? null : highlighter.Highlight(token);
-                paragraph.Append(token, style);
-            }
-
-            return paragraph;
+            return highlighter.BuildHighlightedText(text);
         }
     }
 }

--- a/src/RadLine/WordHighlighter.cs
+++ b/src/RadLine/WordHighlighter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using Spectre.Console;
+using Spectre.Console.Rendering;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace RadLine
 {
@@ -19,10 +21,22 @@ namespace RadLine
             return this;
         }
 
-        Style? IHighlighter.Highlight(string token)
+        IRenderable IHighlighter.BuildHighlightedText(string text)
         {
-            _words.TryGetValue(token, out var style);
-            return style;
+            var paragraph = new Paragraph();
+            foreach (var token in StringTokenizer.Tokenize(text))
+            {
+                if (_words.TryGetValue(token, out var style))
+                {
+                    paragraph.Append(token, style);
+                }
+                else
+                {
+                    paragraph.Append(token, null);
+                }
+            }
+
+            return paragraph;
         }
     }
 }


### PR DESCRIPTION
I know "no new features" so let's see that as a possible improvement for future versions.
The Highlighting interface works on tokens but for my use case I need context sensitive highlighting so it needs to work on the whole line and the highlighter to tokenize the line.

I moved the word highlighting to WordHighlighter so consuming code using that doesn't break.