### PR TITLE
Added line decoration renderer.

### DIFF
--- a/src/RadLine/ILineDecorationRenderer.cs
+++ b/src/RadLine/ILineDecorationRenderer.cs
@@ -1,0 +1,7 @@
+namespace RadLine
+{
+    public interface ILineDecorationRenderer
+    {
+        void RenderLineDecoration(LineBuffer buffer);
+    }
+}

--- a/src/RadLine/LineEditor.cs
+++ b/src/RadLine/LineEditor.cs
@@ -26,6 +26,8 @@ namespace RadLine
         public IHighlighter? Highlighter { get; init; }
         public ILineEditorHistory History => _history;
 
+        public ILineDecorationRenderer? LineDecorationRenderer { get; init; }
+
         public LineEditor(IAnsiConsole? terminal = null, IInputSource? source = null, IServiceProvider? provider = null)
         {
             _console = terminal ?? AnsiConsole.Console;
@@ -185,6 +187,7 @@ namespace RadLine
 
                 // Render the line
                 _renderer.RenderLine(state);
+                LineDecorationRenderer?.RenderLineDecoration(state.Buffer);
             }
         }
 


### PR DESCRIPTION
I use the line decoration renderer to add preview to completion items.

For example:
![grafik](https://github.com/spectreconsole/radline/assets/341098/61700bf5-31c9-41c7-a296-62216f5c490d)

This shows the preview of "it" when pressing tab the completion will extend the word to "exit".