### PR TITLE
Put empty strings into the history intermediate buffer.

### DIFF
--- a/src/RadLine/LineEditorHistory.cs
+++ b/src/RadLine/LineEditorHistory.cs
@@ -88,11 +88,8 @@ namespace RadLine
             if ((_current == null && _intermediate == null) || _showIntermediate)
             {
                 // Got something written that we don't want to lose?
-                if (!string.IsNullOrWhiteSpace(state.Text))
-                {
-                    // Store the interediate buffer so it wont get lost.
-                    _intermediate = state.GetBuffers().ToArray();
-                }
+                // Store the interediate buffer so it wont get lost.
+                _intermediate = state.GetBuffers().ToArray();
             }
 
             _showIntermediate = false;


### PR DESCRIPTION
The issue is when using the history there is no way to get back to the empty input string.
All shells I know work like that. Was there a reason for the length check?